### PR TITLE
修复tree node展开时，折叠动画抖动

### DIFF
--- a/src/components/ElSelectTree.vue
+++ b/src/components/ElSelectTree.vue
@@ -250,6 +250,8 @@ export default class ElSelectTree extends Mixins(ElSelectMixin, ElTreeMixin) {
       flex: 1;
       padding: 0 30px 0 0;
       background: transparent !important;
+      height: unset;
+      line-height: unset;
       &.selected:after {
         right: 10px;
       }


### PR DESCRIPTION
原因是el-select-dropdown__item的高度超出了el-tree-node__content的高度，导致el-collapse-transition计算出现了问题。